### PR TITLE
feat: Add user tournament history endpoint

### DIFF
--- a/tournaments/tests.py
+++ b/tournaments/tests.py
@@ -171,6 +171,31 @@ class TournamentAPITest(APITestCase):
         self.assertTrue(match.is_confirmed)
         self.assertEqual(match.winner_user, self.user1)
 
+    def test_get_user_tournament_history(self):
+        """
+        Ensure a user can retrieve their tournament history.
+        """
+        # user1 joins the individual tournament
+        self.individual_tournament.participants.add(self.user1)
+
+        # Authenticate as user1
+        self.client.force_authenticate(user=self.user1)
+
+        # Get the tournament history
+        url = reverse("my-tournament-history")
+        response = self.client.get(url)
+
+        # Check the response
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], self.individual_tournament.name)
+
+        # user2 should have no history
+        self.client.force_authenticate(user=self.user2)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
 
 class ReportTests(APITestCase):
     def setUp(self):

--- a/tournaments/urls.py
+++ b/tournaments/urls.py
@@ -7,10 +7,16 @@ from .views import (
     TopTournamentsView,
     TotalPrizeMoneyView,
     TotalTournamentsView,
+    UserTournamentHistoryView,
 )
 
 urlpatterns = [
     path("", include(router.urls)),
+    path(
+        "my-tournaments/",
+        UserTournamentHistoryView.as_view(),
+        name="my-tournament-history",
+    ),
     path("admin/reports/", AdminReportListView.as_view(), name="admin-reports"),
     path(
         "admin/winner-submissions/",

--- a/tournaments/views.py
+++ b/tournaments/views.py
@@ -492,3 +492,20 @@ class TotalTournamentsView(APIView):
     def get(self, request):
         total_tournaments = Tournament.objects.count()
         return Response({"total_tournaments": total_tournaments})
+
+
+class UserTournamentHistoryView(generics.ListAPIView):
+    """
+    API view to list tournaments a user has participated in.
+    """
+
+    serializer_class = TournamentSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        """
+        This view should return a list of all the tournaments
+        for the currently authenticated user.
+        """
+        user = self.request.user
+        return Tournament.objects.filter(participants=user)


### PR DESCRIPTION
This commit introduces a new feature that allows users to view a history of the tournaments they have participated in.

- A new `UserTournamentHistoryView` is created in `tournaments/views.py` to handle the logic for retrieving the tournament history for the authenticated user.
- A corresponding URL `/my-tournaments/` is added to `tournaments/urls.py`.
- A unit test is added to `tournaments/tests.py` to ensure the new endpoint works correctly.