### PR TITLE
feat: Enable django-axes and django-ratelimit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ Django==5.2.4
 django-cors-headers==4.7.0
 django-filter==25.1
 django-phonenumber-field==8.1.0
+django-axes==8.0.0
 django-ratelimit==4.1.0
 django-redis==6.0.0
 django-sslserver==0.22

--- a/tournament_project/settings.py
+++ b/tournament_project/settings.py
@@ -52,20 +52,20 @@ INSTALLED_APPS = [
     "tournaments",
     "wallet",
     "corsheaders",
-    # "axes",
+    "axes",
     "chat",
     "notifications",
     "django_celery_results",
     "djoser",
     "support",
-    # "django_ratelimit",
+    "django_ratelimit",
     'sslserver',
     'verification',
     'rewards',
 ]
 
 AUTHENTICATION_BACKENDS = [
-    # "axes.backends.AxesStandaloneBackend",
+    "axes.backends.AxesStandaloneBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
 
@@ -78,7 +78,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    # "axes.middleware.AxesMiddleware",
+    "axes.middleware.AxesMiddleware",
 ]
 
 ROOT_URLCONF = "tournament_project.urls"
@@ -288,15 +288,31 @@ CACHES = {
 if "test" in sys.argv:
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/1",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
         },
         "connection-errors": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/1",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
         },
         "connection-errors-redis": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/1",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
         },
         "instant-expiration": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/1",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
         },
     }


### PR DESCRIPTION
Enabled django-axes and django-ratelimit to enhance security and protect against brute-force and denial-of-service attacks.

- Uncommented `axes` and `django_ratelimit` in `INSTALLED_APPS`.
- Uncommented `axes.backends.AxesStandaloneBackend` in `AUTHENTICATION_BACKENDS`.
- Uncommented `axes.middleware.AxesMiddleware` in `MIDDLEWARE`.
- Added `django-axes` to `requirements.txt`.
- Configured the test environment to use Redis as the cache backend to ensure compatibility with `django-ratelimit`.