### PR TITLE
Fix: Correct ASGI import paths for chat and notifications

### DIFF
--- a/tournament_project/asgi.py
+++ b/tournament_project/asgi.py
@@ -13,8 +13,8 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 
-import tournament_project.chat.routing
-import tournament_project.notifications.routing
+import chat.routing
+import notifications.routing
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tournament_project.settings")
 
@@ -23,8 +23,8 @@ application = ProtocolTypeRouter(
         "http": get_asgi_application(),
         "websocket": AuthMiddlewareStack(
             URLRouter(
-                tournament_project.chat.routing.websocket_urlpatterns
-                + tournament_project.notifications.routing.websocket_urlpatterns
+                chat.routing.websocket_urlpatterns
+                + notifications.routing.websocket_urlpatterns
             )
         ),
     }


### PR DESCRIPTION
The ASGI configuration in `tournament_project/asgi.py` contained incorrect import paths for the `chat` and `notifications` routing modules. It was attempting to import them from within the `tournament_project` package, whereas they are located at the project root.

This error would cause a `ModuleNotFoundError` when the Daphne server starts, preventing WebSocket connections from being established.

This commit corrects the import paths, allowing the ASGI application to correctly route WebSocket traffic to the appropriate consumers. This ensures the Docker services can start and run correctly as intended.