### PR TITLE
Fix(daphne): Correct command for daphne service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   daphne:
     build: .
     entrypoint: /app/entrypoint.sh
-    command: daphne -b 0.0.0.0 -p 8001 tournament_project.asgi:application
+    command: daphne daphne -b 0.0.0.0 -p 8001 tournament_project.asgi:application
     volumes:
       - static_volume:/app/staticfiles
       - media_volume:/app/media


### PR DESCRIPTION
The daphne service in docker-compose.yml was failing because the entrypoint script was consuming the executable name ('daphne') as a service identifier and then trying to execute the remaining arguments.

This change modifies the command to `daphne daphne ...`, providing 'daphne' as the service identifier for the entrypoint script and 'daphne' as the executable to run. This aligns the command with the pattern used by other services in the project and resolves the startup error.