### PR TITLE
Fix Daphne container crashing on startup

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ drf-spectacular
 # Async & Real-time
 celery
 channels
+daphne
 redis
 
 # Database & Environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ annotated-types==0.6.0
 asgiref==3.9.1
     # via
     #   channels
+    #   daphne
     #   django
     #   django-axes
     #   django-cors-headers
@@ -32,6 +33,12 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
+    #   service-identity
+    #   twisted
+autobahn==24.4.2
+    # via daphne
+automat==25.4.16
+    # via twisted
 billiard==4.2.1
     # via celery
 black==25.1.0
@@ -74,10 +81,18 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
+constantly==23.10.4
+    # via twisted
 coverage==7.10.3
     # via -r requirements.in
 cryptography==45.0.6
-    # via social-auth-core
+    # via
+    #   autobahn
+    #   pyopenssl
+    #   service-identity
+    #   social-auth-core
+daphne==4.2.1
+    # via -r requirements.in
 defusedxml==0.7.1
     # via
     #   python3-openid
@@ -146,11 +161,19 @@ frozenlist==1.7.0
     #   aiosignal
 gunicorn==23.0.0
     # via -r requirements.in
+hyperlink==21.0.0
+    # via
+    #   autobahn
+    #   twisted
 idna==3.4
     # via
+    #   hyperlink
     #   requests
+    #   twisted
     #   yarl
     #   zarinpal
+incremental==24.7.2
+    # via twisted
 inflection==0.5.1
     # via drf-spectacular
 jmespath==1.0.1
@@ -197,6 +220,12 @@ propcache==0.3.2
     # via yarl
 psycopg2-binary==2.9.10
     # via -r requirements.in
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   service-identity
+pyasn1-modules==0.4.2
+    # via service-identity
 pycodestyle==2.14.0
     # via flake8
 pycparser==2.22
@@ -214,6 +243,8 @@ pyjwt==2.10.1
     #   djangorestframework-simplejwt
     #   social-auth-core
     #   twilio
+pyopenssl==22.0.0
+    # via twisted
 pyproject-hooks==1.2.0
     # via
     #   build
@@ -251,6 +282,8 @@ rpds-py==0.27.0
     #   referencing
 s3transfer==0.13.1
     # via boto3
+service-identity==24.2.0
+    # via twisted
 six==1.17.0
     # via python-dateutil
 smsir-python==1.0.8
@@ -265,12 +298,17 @@ sqlparse==0.5.3
     # via django
 twilio==9.7.0
     # via -r requirements.in
+twisted[tls]==25.5.0
+    # via daphne
+txaio==25.6.1
+    # via autobahn
 typing-extensions==4.8.0
     # via
     #   aiosignal
     #   pydantic
     #   pydantic-core
     #   referencing
+    #   twisted
     #   zarinpal
 tzdata==2025.2
     # via kombu
@@ -294,6 +332,8 @@ yarl==1.20.1
     # via aiohttp
 zarinpal==1.0.0
     # via -r requirements.in
+zope-interface==7.2
+    # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
The daphne container was failing to start with exit code 127, which indicates "command not found".

This was because the `daphne` package was not included in the project's dependencies in `requirements.txt`.

This change adds `daphne` to `requirements.in` and regenerates `requirements.txt` to include it. With this change, the `daphne` command will be available in the container, and the service will be able to start correctly.