### PR TITLE
Fix tournament admin display and creation errors

### DIFF
--- a/tournaments/models.py
+++ b/tournaments/models.py
@@ -15,6 +15,9 @@ class Game(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField()
 
+    def __str__(self):
+        return self.name
+
 
 class GameManager(models.Model):
     user = models.ForeignKey(
@@ -127,14 +130,15 @@ class Tournament(models.Model):
             raise ValidationError("End date must be after start date.")
         if not self.is_free and self.entry_fee is None:
             raise ValidationError("Entry fee must be set for paid tournaments.")
-        if self.type == "individual" and self.teams.exists():
-            raise ValidationError(
-                "Individual tournaments cannot have team participants."
-            )
-        if self.type == "team" and self.participants.exists():
-            raise ValidationError(
-                "Team tournaments cannot have individual participants."
-            )
+        if self.pk is not None:
+            if self.type == "individual" and self.teams.exists():
+                raise ValidationError(
+                    "Individual tournaments cannot have team participants."
+                )
+            if self.type == "team" and self.participants.exists():
+                raise ValidationError(
+                    "Team tournaments cannot have individual participants."
+                )
         if self.type == "individual" and self.team_size != 1:
             raise ValidationError("Individual tournaments must have a team size of 1.")
         if self.type == "team" and self.team_size <= 1:


### PR DESCRIPTION
Adds a `__str__` method to the `Game` model to ensure that game names are displayed correctly in the admin interface, rather than showing a generic object representation.

Modifies the `clean` method of the `Tournament` model to prevent a `ValueError` during the creation of new tournaments. The validation logic that accesses many-to-many fields is now wrapped in a condition to ensure it only runs on instances that have already been saved to the database (i.e., have a primary key). This resolves the crash that occurred when creating a tournament from the admin panel.