### PR TITLE
feat: Add admin login view

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -116,3 +116,10 @@ class TopTeamSerializer(serializers.ModelSerializer):
     class Meta:
         model = Team
         fields = ("id", "name", "total_winnings")
+
+
+class AdminLoginSerializer(serializers.Serializer):
+    """Serializer for admin login."""
+
+    username = serializers.CharField()
+    password = serializers.CharField(write_only=True)

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,9 +1,10 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import (DashboardView, RoleViewSet, TeamMatchHistoryView,
-                    TeamViewSet, TopPlayersView, TopTeamsView,
-                    TotalPlayersView, UserMatchHistoryView, UserViewSet)
+from .views import (AdminLoginView, DashboardView, RoleViewSet,
+                    TeamMatchHistoryView, TeamViewSet, TopPlayersView,
+                    TopTeamsView, TotalPlayersView, UserMatchHistoryView,
+                    UserViewSet)
 
 router = DefaultRouter()
 router.register(r"users", UserViewSet)
@@ -26,4 +27,5 @@ urlpatterns = [
     path("top-players/", TopPlayersView.as_view(), name="top-players"),
     path("top-teams/", TopTeamsView.as_view(), name="top-teams"),
     path("total-players/", TotalPlayersView.as_view(), name="total-players"),
+    path("auth/admin-login/", AdminLoginView.as_view(), name="admin-login"),
 ]


### PR DESCRIPTION
This commit introduces a new endpoint for admin login.

- A new `AdminLoginView` is created to handle authentication for admin users. It takes username and password, verifies the user's credentials, and checks if the user is a staff member.
- If the user is a staff member, it returns JWT refresh and access tokens.
- A new `AdminLoginSerializer` is added to validate the login credentials.
- A new URL `auth/admin-login/` is registered to route to the new view.