### PR TITLE
feat: Add profile picture to TopPlayerByRankSerializer

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -177,7 +177,15 @@ class TopPlayerByRankSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ("id", "username", "score", "rank", "total_winnings", "wins")
+        fields = (
+            "id",
+            "username",
+            "score",
+            "rank",
+            "total_winnings",
+            "wins",
+            "profile_picture",
+        )
 
 
 class AdminLoginSerializer(serializers.Serializer):


### PR DESCRIPTION
Adds the `profile_picture` field to the `TopPlayerByRankSerializer` to include the user's profile picture in the API response for the top players by rank endpoint.