### PR TITLE
feat: Enhance Django admin with professional features

### DIFF
--- a/chat/admin.py
+++ b/chat/admin.py
@@ -1,0 +1,37 @@
+from django.contrib import admin
+
+from .models import Attachment, Conversation, Message
+
+
+class MessageInline(admin.TabularInline):
+    model = Message
+    extra = 1
+    autocomplete_fields = ("sender",)
+
+
+class AttachmentInline(admin.TabularInline):
+    model = Attachment
+    extra = 1
+
+
+@admin.register(Conversation)
+class ConversationAdmin(admin.ModelAdmin):
+    list_display = ("id", "created_at", "support_ticket")
+    search_fields = ("participants__username", "support_ticket__title")
+    autocomplete_fields = ("participants", "support_ticket")
+    inlines = [MessageInline]
+
+
+@admin.register(Message)
+class MessageAdmin(admin.ModelAdmin):
+    list_display = ("sender", "conversation", "timestamp", "is_read")
+    list_filter = ("is_read", "timestamp")
+    search_fields = ("sender__username", "content")
+    autocomplete_fields = ("conversation", "sender")
+    inlines = [AttachmentInline]
+
+
+@admin.register(Attachment)
+class AttachmentAdmin(admin.ModelAdmin):
+    list_display = ("message", "file", "uploaded_at")
+    autocomplete_fields = ("message",)

--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+
+from .models import Notification
+
+
+@admin.register(Notification)
+class NotificationAdmin(admin.ModelAdmin):
+    list_display = ("user", "message", "notification_type", "is_read", "timestamp")
+    list_filter = ("notification_type", "is_read", "timestamp")
+    search_fields = ("user__username", "message")
+    autocomplete_fields = ("user",)

--- a/rewards/admin.py
+++ b/rewards/admin.py
@@ -1,0 +1,30 @@
+from django.contrib import admin
+
+from .models import Prize, Spin, Wheel
+
+
+class PrizeInline(admin.TabularInline):
+    model = Prize
+    extra = 1
+
+
+@admin.register(Wheel)
+class WheelAdmin(admin.ModelAdmin):
+    list_display = ("name", "required_rank")
+    search_fields = ("name",)
+    autocomplete_fields = ("required_rank",)
+    inlines = [PrizeInline]
+
+
+@admin.register(Prize)
+class PrizeAdmin(admin.ModelAdmin):
+    list_display = ("name", "wheel", "chance")
+    search_fields = ("name",)
+    autocomplete_fields = ("wheel",)
+
+
+@admin.register(Spin)
+class SpinAdmin(admin.ModelAdmin):
+    list_display = ("user", "wheel", "prize", "timestamp")
+    search_fields = ("user__username", "wheel__name", "prize__name")
+    autocomplete_fields = ("user", "wheel", "prize")

--- a/support/admin.py
+++ b/support/admin.py
@@ -1,0 +1,66 @@
+from django.contrib import admin, messages
+
+from chat.models import Conversation
+from .models import SupportAssignment, Ticket, TicketMessage
+
+
+class ConversationInline(admin.TabularInline):
+    model = Conversation
+    extra = 0
+    verbose_name_plural = "Conversations"
+    can_delete = False
+    show_change_link = True
+    fields = ("id", "created_at")
+    readonly_fields = ("id", "created_at")
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+class TicketMessageInline(admin.TabularInline):
+    model = TicketMessage
+    extra = 1
+    autocomplete_fields = ("user",)
+    readonly_fields = ("created_at",)
+
+
+@admin.register(Ticket)
+class TicketAdmin(admin.ModelAdmin):
+    list_display = ("title", "user", "status", "created_at")
+    list_filter = ("status", "created_at")
+    search_fields = ("title", "user__username")
+    autocomplete_fields = ("user",)
+    inlines = [TicketMessageInline, ConversationInline]
+    actions = ["close_tickets"]
+
+    fieldsets = (
+        ("Ticket Details", {"fields": ("title", "user", "status")}),
+        ("Timestamps", {"fields": ("created_at",)}),
+    )
+    readonly_fields = ("created_at",)
+
+    def close_tickets(self, request, queryset):
+        updated_count = queryset.update(status="closed")
+        self.message_user(
+            request,
+            f"{updated_count} tickets have been marked as closed.",
+            messages.SUCCESS,
+        )
+
+    close_tickets.short_description = "Close selected tickets"
+
+
+@admin.register(TicketMessage)
+class TicketMessageAdmin(admin.ModelAdmin):
+    list_display = ("ticket", "user", "created_at")
+    search_fields = ("ticket__title", "user__username", "message")
+    autocomplete_fields = ("ticket", "user")
+    readonly_fields = ("created_at",)
+
+
+@admin.register(SupportAssignment)
+class SupportAssignmentAdmin(admin.ModelAdmin):
+    list_display = ("support_person", "game", "head_support")
+    list_filter = ("head_support", "game")
+    search_fields = ("support_person__username", "game__name")
+    autocomplete_fields = ("support_person", "game")

--- a/tournaments/admin.py
+++ b/tournaments/admin.py
@@ -1,0 +1,237 @@
+from django.contrib import admin, messages
+
+from .models import (
+    Game,
+    GameImage,
+    GameManager,
+    Match,
+    Participant,
+    Rank,
+    Report,
+    Scoring,
+    Tournament,
+    WinnerSubmission,
+)
+
+
+class GameManagerInline(admin.TabularInline):
+    model = GameManager
+    extra = 1
+    autocomplete_fields = ("user",)
+
+
+class GameImageInline(admin.TabularInline):
+    model = GameImage
+    extra = 1
+
+
+class ParticipantInline(admin.TabularInline):
+    model = Participant
+    extra = 1
+    autocomplete_fields = ("user",)
+
+
+class MatchInline(admin.TabularInline):
+    model = Match
+    extra = 1
+    autocomplete_fields = (
+        "participant1_user",
+        "participant2_user",
+        "participant1_team",
+        "participant2_team",
+        "winner_user",
+        "winner_team",
+    )
+    show_change_link = True
+
+
+class ScoringInline(admin.TabularInline):
+    model = Scoring
+    extra = 1
+    autocomplete_fields = ("user",)
+
+
+class ReportInline(admin.TabularInline):
+    model = Report
+    extra = 1
+    autocomplete_fields = ("reporter", "reported_user")
+    show_change_link = True
+
+
+@admin.register(Rank)
+class RankAdmin(admin.ModelAdmin):
+    list_display = ("name", "required_score")
+    search_fields = ("name",)
+
+
+@admin.register(Game)
+class GameAdmin(admin.ModelAdmin):
+    list_display = ("name",)
+    search_fields = ("name",)
+    inlines = [GameManagerInline, GameImageInline]
+
+
+@admin.register(GameManager)
+class GameManagerAdmin(admin.ModelAdmin):
+    list_display = ("user", "game")
+    autocomplete_fields = ("user", "game")
+
+
+@admin.register(Scoring)
+class ScoringAdmin(admin.ModelAdmin):
+    list_display = ("tournament", "user", "score")
+    autocomplete_fields = ("tournament", "user")
+
+
+@admin.register(GameImage)
+class GameImageAdmin(admin.ModelAdmin):
+    list_display = ("game", "image_type")
+    list_filter = ("image_type",)
+    autocomplete_fields = ("game",)
+
+
+@admin.register(Tournament)
+class TournamentAdmin(admin.ModelAdmin):
+    list_display = ("name", "game", "type", "mode", "start_date", "end_date", "is_free")
+    search_fields = ("name", "game__name")
+    list_filter = ("type", "mode", "is_free", "game", "start_date", "end_date")
+    autocomplete_fields = (
+        "game",
+        "participants",
+        "teams",
+        "creator",
+        "min_rank",
+        "max_rank",
+        "top_players",
+        "top_teams",
+    )
+    inlines = [ParticipantInline, MatchInline, ScoringInline]
+    fieldsets = (
+        ("Tournament Info", {"fields": ("name", "game", "creator", "rules")}),
+        (
+            "Configuration",
+            {
+                "fields": (
+                    "type",
+                    "mode",
+                    "max_participants",
+                    "team_size",
+                    "is_free",
+                    "entry_fee",
+                )
+            },
+        ),
+        ("Schedule", {"fields": ("start_date", "end_date", "countdown_start_time")}),
+        (
+            "Restrictions",
+            {"fields": ("required_verification_level", "min_rank", "max_rank")},
+        ),
+        (
+            "Participants & Winners",
+            {"fields": ("participants", "teams", "top_players", "top_teams")},
+        ),
+    )
+
+
+@admin.register(Participant)
+class ParticipantAdmin(admin.ModelAdmin):
+    list_display = ("user", "tournament", "status", "rank", "prize")
+    list_filter = ("status", "tournament")
+    search_fields = ("user__username", "tournament__name")
+    autocomplete_fields = ("user", "tournament")
+
+
+@admin.register(Match)
+class MatchAdmin(admin.ModelAdmin):
+    list_display = (
+        "tournament",
+        "round",
+        "__str__",
+        "is_confirmed",
+        "is_disputed",
+    )
+    list_filter = ("is_confirmed", "is_disputed", "tournament", "match_type")
+    search_fields = (
+        "tournament__name",
+        "participant1_user__username",
+        "participant2_user__username",
+        "participant1_team__name",
+        "participant2_team__name",
+    )
+    autocomplete_fields = (
+        "tournament",
+        "participant1_user",
+        "participant2_user",
+        "participant1_team",
+        "participant2_team",
+        "winner_user",
+        "winner_team",
+    )
+    inlines = [ReportInline]
+    actions = ["confirm_matches"]
+
+    fieldsets = (
+        ("Match Info", {"fields": ("tournament", "round", "match_type")}),
+        (
+            "Participants",
+            {
+                "fields": (
+                    "participant1_user",
+                    "participant2_user",
+                    "participant1_team",
+                    "participant2_team",
+                )
+            },
+        ),
+        ("Result", {"fields": ("winner_user", "winner_team", "result_proof")}),
+        (
+            "Status",
+            {"fields": ("is_confirmed", "is_disputed", "dispute_reason")},
+        ),
+        ("Connection Details", {"fields": ("room_id", "password")}),
+    )
+
+    def confirm_matches(self, request, queryset):
+        updated_count = queryset.update(is_confirmed=True)
+        self.message_user(
+            request, f"{updated_count} matches have been confirmed.", messages.SUCCESS
+        )
+
+    confirm_matches.short_description = "Confirm selected matches"
+
+
+@admin.register(Report)
+class ReportAdmin(admin.ModelAdmin):
+    list_display = ("reporter", "reported_user", "match", "status", "created_at")
+    list_filter = ("status",)
+    search_fields = (
+        "reporter__username",
+        "reported_user__username",
+        "match__tournament__name",
+    )
+    autocomplete_fields = ("reporter", "reported_user", "match")
+    actions = ["resolve_reports", "reject_reports"]
+
+    def resolve_reports(self, request, queryset):
+        updated_count = queryset.update(status="resolved")
+        self.message_user(
+            request, f"{updated_count} reports have been resolved.", messages.SUCCESS
+        )
+
+    resolve_reports.short_description = "Mark selected reports as resolved"
+
+    def reject_reports(self, request, queryset):
+        updated_count = queryset.update(status="rejected")
+        self.message_user(
+            request, f"{updated_count} reports have been rejected.", messages.SUCCESS
+        )
+
+    reject_reports.short_description = "Mark selected reports as rejected"
+
+
+@admin.register(WinnerSubmission)
+class WinnerSubmissionAdmin(admin.ModelAdmin):
+    list_display = ("winner", "tournament", "status", "created_at")
+    list_filter = ("status", "tournament")
+    search_fields = ("winner__username", "tournament__name")
+    autocomplete_fields = ("winner", "tournament")

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,0 +1,126 @@
+from django.contrib import admin, messages
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+
+from .models import (
+    InGameID,
+    OTP,
+    Role,
+    Team,
+    TeamInvitation,
+    TeamMembership,
+    User,
+)
+
+
+class InGameIDInline(admin.TabularInline):
+    model = InGameID
+    extra = 1
+    autocomplete_fields = ("game",)
+
+
+class TeamMembershipInline(admin.TabularInline):
+    model = TeamMembership
+    extra = 1
+    autocomplete_fields = ("team",)
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    list_display = (
+        "username",
+        "email",
+        "phone_number",
+        "score",
+        "rank",
+        "is_staff",
+    )
+    search_fields = ("username", "first_name", "last_name", "email", "phone_number")
+    list_filter = ("is_staff", "is_superuser", "is_active", "groups", "rank")
+    autocomplete_fields = ("rank", "groups")
+    inlines = [InGameIDInline, TeamMembershipInline]
+    readonly_fields = ("score", "rank")
+
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        (
+            "Personal info",
+            {"fields": ("first_name", "last_name", "email", "phone_number")},
+        ),
+        ("Game Profile", {"fields": ("score", "rank", "profile_picture")}),
+        (
+            "Permissions",
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                )
+            },
+        ),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
+
+    actions = ["reset_score"]
+
+    def reset_score(self, request, queryset):
+        updated_count = queryset.update(score=0)
+        self.message_user(
+            request,
+            f"{updated_count} users had their score reset to 0.",
+            messages.SUCCESS,
+        )
+
+    reset_score.short_description = "Reset score of selected users"
+
+
+@admin.register(Role)
+class RoleAdmin(admin.ModelAdmin):
+    list_display = ("group", "is_default")
+    search_fields = ("group__name",)
+    list_filter = ("is_default",)
+    autocomplete_fields = ("group",)
+
+
+@admin.register(InGameID)
+class InGameIDAdmin(admin.ModelAdmin):
+    list_display = ("user", "game", "player_id")
+    search_fields = ("user__username", "game__name", "player_id")
+    autocomplete_fields = ("user", "game")
+
+
+@admin.register(Team)
+class TeamAdmin(admin.ModelAdmin):
+    list_display = ("name", "captain", "max_members")
+    search_fields = ("name", "captain__username")
+    autocomplete_fields = ("captain", "members")
+    inlines = [TeamMembershipInline]
+
+    fieldsets = (
+        ("Team Info", {"fields": ("name", "team_picture", "captain", "max_members")}),
+        ("Members", {"fields": ("members",)}),
+    )
+
+
+@admin.register(TeamMembership)
+class TeamMembershipAdmin(admin.ModelAdmin):
+    list_display = ("user", "team", "date_joined")
+    search_fields = ("user__username", "team__name")
+    autocomplete_fields = ("user", "team")
+
+
+@admin.register(TeamInvitation)
+class TeamInvitationAdmin(admin.ModelAdmin):
+    list_display = ("from_user", "to_user", "team", "status", "timestamp")
+    search_fields = ("from_user__username", "to_user__username", "team__name")
+    list_filter = ("status",)
+    autocomplete_fields = ("from_user", "to_user", "team")
+
+
+@admin.register(OTP)
+class OTPAdmin(admin.ModelAdmin):
+    list_display = ("user", "code", "created_at", "is_active")
+    search_fields = ("user__username",)
+    list_filter = ("is_active",)
+    autocomplete_fields = ("user",)

--- a/verification/admin.py
+++ b/verification/admin.py
@@ -1,0 +1,50 @@
+from django.contrib import admin, messages
+
+from .models import Verification
+
+
+@admin.register(Verification)
+class VerificationAdmin(admin.ModelAdmin):
+    list_display = ("user", "level", "is_verified", "updated_at")
+    list_filter = ("level", "is_verified")
+    search_fields = ("user__username",)
+    autocomplete_fields = ("user",)
+    readonly_fields = ("created_at", "updated_at")
+    actions = ["approve_verifications", "reject_verifications"]
+
+    fieldsets = (
+        ("User Info", {"fields": ("user",)}),
+        (
+            "Verification Details",
+            {
+                "fields": (
+                    "level",
+                    "is_verified",
+                    "id_card_image",
+                    "selfie_image",
+                    "video",
+                )
+            },
+        ),
+        ("Timestamps", {"fields": ("created_at", "updated_at")}),
+    )
+
+    def approve_verifications(self, request, queryset):
+        updated_count = queryset.update(is_verified=True)
+        self.message_user(
+            request,
+            f"{updated_count} verifications have been approved.",
+            messages.SUCCESS,
+        )
+
+    approve_verifications.short_description = "Approve selected verifications"
+
+    def reject_verifications(self, request, queryset):
+        updated_count = queryset.update(is_verified=False)
+        self.message_user(
+            request,
+            f"{updated_count} verifications have been rejected.",
+            messages.WARNING,
+        )
+
+    reject_verifications.short_description = "Reject selected verifications"

--- a/wallet/admin.py
+++ b/wallet/admin.py
@@ -1,0 +1,43 @@
+from django.contrib import admin
+
+from .models import Transaction, Wallet
+
+
+class TransactionInline(admin.TabularInline):
+    model = Transaction
+    extra = 1
+    readonly_fields = ("amount", "transaction_type", "timestamp", "description")
+    can_delete = False
+    show_change_link = True
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+@admin.register(Wallet)
+class WalletAdmin(admin.ModelAdmin):
+    list_display = ("user", "total_balance", "withdrawable_balance")
+    search_fields = ("user__username",)
+    autocomplete_fields = ("user",)
+    inlines = [TransactionInline]
+    readonly_fields = ("total_balance", "withdrawable_balance")
+
+    fieldsets = (
+        ("Owner", {"fields": ("user",)}),
+        ("Balance", {"fields": ("total_balance", "withdrawable_balance")}),
+    )
+
+
+@admin.register(Transaction)
+class TransactionAdmin(admin.ModelAdmin):
+    list_display = ("wallet", "amount", "transaction_type", "timestamp")
+    list_filter = ("transaction_type", "timestamp")
+    search_fields = ("wallet__user__username", "description")
+    autocomplete_fields = ("wallet",)
+    readonly_fields = ("wallet", "amount", "transaction_type", "timestamp")
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
This commit enhances the previously generated `admin.py` files to provide a more professional and user-friendly experience.

The following improvements have been made across various applications:
- **Fieldsets**: `fieldsets` are used to group related fields in the admin detail pages for better organization.
- **Readonly Fields**: Calculated or system-managed fields (e.g., user scores, wallet balances) are now set to readonly to prevent accidental manual edits.
- **Custom Actions**: Custom admin actions have been added to streamline common administrative tasks, such as:
  - Resetting user scores.
  - Confirming tournament matches.
  - Resolving/rejecting reports.
  - Closing support tickets.
  - Approving/rejecting user verifications.
- **Improved Inlines**: Inlines are made more robust by setting some fields to readonly and controlling add/delete permissions where appropriate.