### PR TITLE
Integrate Jalali datepicker for tournaments

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -61,3 +61,4 @@ django-silk
 django-select2
 django-tempus-dominus
 django-formtools
+django-jalali-date

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,6 +114,7 @@ django==5.2.5
     #   django-formtools
     #   django-guardian
     #   django-import-export
+    #   django-jalali-date
     #   django-phonenumber-field
     #   django-redis
     #   django-select2
@@ -144,6 +145,8 @@ django-formtools==2.5.1
 django-guardian==3.0.3
     # via -r requirements.in
 django-import-export==4.3.9
+    # via -r requirements.in
+django-jalali-date==2.0.0
     # via -r requirements.in
 django-phonenumber-field==8.1.0
     # via -r requirements.in
@@ -207,6 +210,10 @@ incremental==24.7.2
     # via twisted
 inflection==0.5.1
     # via drf-spectacular
+jalali-core==1.0.0
+    # via jdatetime
+jdatetime==5.2.0
+    # via django-jalali-date
 jmespath==1.0.1
     # via
     #   boto3

--- a/tournament_project/settings.py
+++ b/tournament_project/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+import locale
 import os
 import sys
 from pathlib import Path
@@ -18,6 +19,11 @@ import dj_database_url
 from dotenv import load_dotenv
 
 load_dotenv()
+
+if sys.platform.startswith("win32"):
+    locale.setlocale(locale.LC_ALL, "Persian_Iran.UTF-8")
+else:
+    locale.setlocale(locale.LC_ALL, "fa_IR.UTF-8")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -76,6 +82,7 @@ INSTALLED_APPS = [
     "import_export",
     "silk",
     "django_select2",
+    "jalali_date",
     "tempus_dominus",
     "formtools",
 ]

--- a/tournaments/admin.py
+++ b/tournaments/admin.py
@@ -10,7 +10,7 @@ from import_export import resources
 from simple_history.admin import SimpleHistoryAdmin
 from guardian.admin import GuardedModelAdmin
 from django_select2.forms import Select2Widget
-from tempus_dominus.widgets import DateTimePicker
+from jalali_date.admin import ModelAdminJalaliMixin
 
 # Local Imports
 from .models import (
@@ -130,6 +130,7 @@ class TournamentImageAdmin(ModelAdmin):
 
 @admin.register(Tournament)
 class TournamentAdmin(
+    ModelAdminJalaliMixin,
     AdminAlertsMixin,
     ImportExportModelAdmin,
     SimpleHistoryAdmin,
@@ -152,12 +153,6 @@ class TournamentAdmin(
 
     formfield_overrides = {
         models.ForeignKey: {"widget": Select2Widget},
-        models.DateTimeField: {
-            "widget": DateTimePicker(
-                options={"useCurrent": True, "collapse": False},
-                attrs={"append": "fa fa-calendar", "icon_toggle": True},
-            )
-        },
     }
 
     fieldsets = (


### PR DESCRIPTION
This commit integrates the `django-jalali-date` library to replace the default Django admin date widget with a Jalali calendar datepicker for the Tournament model.

Key changes:
- Added `django-jalali-date` to the project dependencies.
- Configured `jalali_date` in `INSTALLED_APPS` and set the locale to `fa_IR`.
- Updated `TournamentAdmin` to use `ModelAdminJalaliMixin`, which automatically provides a Jalali datepicker for `DateTimeField` fields.
- Removed the previous `tempus-dominus` widget override for `DateTimeField` in `TournamentAdmin`.

This addresses the user's request to have a Jalali calendar and a date picker dialog for selecting tournament start and end dates in the Django admin.