### PR TITLE
Fix unsupported locale error and increase nginx upload limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,17 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \
     netcat-openbsd \
+    locales \
     && rm -rf /var/lib/apt/lists/*
+
+# Generate locale
+RUN echo "fa_IR.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+# Set environment variables for locale
+ENV LANG fa_IR.UTF-8
+ENV LANGUAGE fa_IR:fa
+ENV LC_ALL fa_IR.UTF-8
 
 # Install dependencies
 COPY requirements.txt /app/

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,6 +20,8 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    client_max_body_size 100m;
+
     location / {
         proxy_pass http://web:8000;
         proxy_set_header Host $host;


### PR DESCRIPTION
- Modify Dockerfile to install and generate the `fa_IR.UTF-8` locale to prevent `locale.Error: unsupported locale setting`.
- Increase `client_max_body_size` in nginx to 100m as requested.