### PR TITLE
Fix migration for adding referral code to User model

### DIFF
--- a/users/migrations/0009_user_referral_code_referral.py
+++ b/users/migrations/0009_user_referral_code_referral.py
@@ -3,6 +3,14 @@
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
+import shortuuid
+
+
+def generate_referral_codes(apps, schema_editor):
+    User = apps.get_model("users", "User")
+    for user in User.objects.all():
+        user.referral_code = shortuuid.uuid()
+        user.save()
 
 
 class Migration(migrations.Migration):
@@ -13,6 +21,12 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
+            model_name="user",
+            name="referral_code",
+            field=models.CharField(blank=True, max_length=22, null=True),
+        ),
+        migrations.RunPython(generate_referral_codes, migrations.RunPython.noop),
+        migrations.AlterField(
             model_name="user",
             name="referral_code",
             field=models.CharField(blank=True, max_length=22, unique=True),


### PR DESCRIPTION
The migration to add a unique `referral_code` to the `User` model was failing on databases with existing users. This was because the `unique=True` constraint could not be applied to a column with multiple empty or NULL values.

This patch modifies the migration to handle this case:
1.  The `referral_code` field is first added as a nullable CharField.
2.  A `RunPython` operation is used to generate a unique `shortuuid` for each existing user.
3.  The field is then altered to be unique and not-nullable, as defined in the model.

This ensures that the migration can be applied safely on databases with existing data.