### PR TITLE
feat(tournaments): Add end_date and start_countdown to TournamentList…

### DIFF
--- a/tournaments/serializers.py
+++ b/tournaments/serializers.py
@@ -171,6 +171,10 @@ class TournamentListSerializer(TournamentReadOnlySerializer):
     A lightweight serializer for listing tournaments, showing only essential fields.
     """
 
+    start_countdown = serializers.DateTimeField(
+        source="countdown_start_time", read_only=True
+    )
+
     class Meta(TournamentReadOnlySerializer.Meta):
         fields = (
             "id",
@@ -178,6 +182,8 @@ class TournamentListSerializer(TournamentReadOnlySerializer):
             "image",
             "game",
             "start_date",
+            "end_date",
+            "start_countdown",
             "is_free",
             "entry_fee",
             "prize_pool",


### PR DESCRIPTION
…Serializer

This change updates the TournamentListSerializer to include the `end_date` and a `start_countdown` field. This provides more information in the tournament list view as requested by the user.